### PR TITLE
bug: Move prepare script to postinstall

### DIFF
--- a/packages/associated-token/package.json
+++ b/packages/associated-token/package.json
@@ -20,7 +20,7 @@
     "docs": "typedoc --out ../../docs/associated-token --mode library --composite false --rootDir src src/index.ts src/*.d.ts",
     "test": "",
     "clean": "rm -rf dist",
-    "prepare": "run-s clean build"
+    "postinstall": "run-s clean build"
   },
   "peerDependencies": {
     "@solana/web3.js": "^0.90.0"

--- a/packages/borsh/package.json
+++ b/packages/borsh/package.json
@@ -19,7 +19,7 @@
     "docs": "typedoc --out ../../docs/borsh --mode library --composite false --rootDir src src/index.ts src/*.d.ts",
     "test": "",
     "clean": "rm -rf dist",
-    "prepare": "run-s clean build"
+    "postinstall": "run-s clean build"
   },
   "dependencies": {
     "bn.js": "^5.1.2",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -19,7 +19,7 @@
     "watch": "tsc --watch",
     "test": "jest test",
     "clean": "rm -rf dist",
-    "prepare": "run-s clean build"
+    "postinstall": "run-s clean build"
   },
   "dependencies": {
     "@project-serum/serum": "^0.13.21",

--- a/packages/pool/package.json
+++ b/packages/pool/package.json
@@ -20,7 +20,7 @@
     "build": "tsc",
     "start": "tsc --watch",
     "clean": "rm -rf dist",
-    "prepare": "run-s clean build",
+    "postinstall": "run-s clean build",
     "docs": "typedoc --out ../../docs/pool --mode library --composite false --rootDir src src/index.ts src/*.d.ts",
     "test": "run-s test:build test:unit test:lint",
     "test:build": "run-s build",

--- a/packages/serum/package.json
+++ b/packages/serum/package.json
@@ -13,7 +13,7 @@
     "build": "tsc",
     "start": "tsc --watch",
     "clean": "rm -rf lib",
-    "prepare": "run-s clean build",
+    "postinstall": "run-s clean build",
     "shell": "node -e \"$(< shell)\" -i --experimental-repl-await",
     "test": "run-s test:unit test:lint test:build",
     "test:build": "run-s build",

--- a/packages/swap/package.json
+++ b/packages/swap/package.json
@@ -13,9 +13,9 @@
   "scripts": {
     "build": "tsc",
     "start": "tsc --watch",
-		"clean": "rm -rf lib",
+    "clean": "rm -rf lib",
     "docs": "typedoc --excludePrivate --out ../../docs/swap src/index.ts --includeVersion --readme none",
-    "prepare": "run-s clean build",
+    "postinstall": "run-s clean build",
     "shell": "node -e \"$(< shell)\" -i --experimental-repl-await"
   },
   "devDependencies": {

--- a/packages/token/package.json
+++ b/packages/token/package.json
@@ -21,7 +21,7 @@
     "start": "tsc --watch",
     "test": "",
     "clean": "rm -rf dist",
-    "prepare": "run-s clean build"
+    "postinstall": "run-s clean build"
   },
   "dependencies": {
     "@project-serum/borsh": "^0.0.1-beta.0",


### PR DESCRIPTION
This is a requirement to deal with the updated version of yarn which no longer respects the prepare script.

More documentation as to why [here](https://github.com/yarnpkg/berry/issues/2305#issuecomment-753468942)