### PR TITLE
bug(pool): Fix build due to bad ts assertion

### DIFF
--- a/packages/pool/src/transactions.ts
+++ b/packages/pool/src/transactions.ts
@@ -153,9 +153,8 @@ export class PoolTransactions {
     };
 
     const mintAccountSpace = 82;
-    const mintAccountLamports = await connection.getMinimumBalanceForRentExemption(
-      mintAccountSpace,
-    );
+    const mintAccountLamports =
+      await connection.getMinimumBalanceForRentExemption(mintAccountSpace);
 
     // Initialize pool token.
     setup.transaction.add(
@@ -379,8 +378,7 @@ export class PoolTransactions {
     if (wrappedSolAccount) {
       transaction.add(
         TokenInstructions.closeAccount({
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          source: wrappedSolAccount!.publicKey,
+          source: (wrappedSolAccount as Account | null)!.publicKey,
           destination: user.owner,
           owner: delegate.publicKey,
         }),


### PR DESCRIPTION
TSC did not realize that a function captured a variable outside of scope, and thus was calling a variable as type never even though it would be changed in the function run.