### PR TITLE
Use active ETH/USDC market

### DIFF
--- a/packages/serum/src/markets.json
+++ b/packages/serum/src/markets.json
@@ -24,7 +24,7 @@
     "programId": "srmqPvymJeFKQ4zGQed1GFppgkRHL9kaELCbyksJtPX"
   },
   {
-    "address": "FZxi3yWkE5mMjyaZj6utmYL54QQYfMCKMcLaQZq4UwnA",
+    "address": "BbJgE7HZMaDp5NTYvRh5jZSkQPVDTU8ubPFtpogUkEj4",
     "deprecated": false,
     "name": "ETH/USDC",
     "programId": "srmqPvymJeFKQ4zGQed1GFppgkRHL9kaELCbyksJtPX"


### PR DESCRIPTION
Context: The market Jump is quoting on has no decimals, and generally does no volume.