### PR TITLE
Create open order accounts with seed

### DIFF
--- a/packages/serum/src/market.ts
+++ b/packages/serum/src/market.ts
@@ -461,22 +461,21 @@ export class Market {
       replaceIfExists = false,
     }: OrderParams,
   ) {
-    const { transaction, signers } = await this.makePlaceOrderTransaction<
-      Account
-    >(connection, {
-      owner,
-      payer,
-      side,
-      price,
-      size,
-      orderType,
-      clientId,
-      openOrdersAddressKey,
-      openOrdersAccount,
-      feeDiscountPubkey,
-      maxTs,
-      replaceIfExists,
-    });
+    const { transaction, signers } =
+      await this.makePlaceOrderTransaction<Account>(connection, {
+        owner,
+        payer,
+        side,
+        price,
+        size,
+        orderType,
+        clientId,
+        openOrdersAddressKey,
+        openOrdersAccount,
+        feeDiscountPubkey,
+        maxTs,
+        replaceIfExists,
+      });
     return await this._sendTransaction(connection, transaction, [
       owner,
       ...signers,
@@ -500,22 +499,21 @@ export class Market {
       feeDiscountPubkey = undefined,
     }: SendTakeParams,
   ) {
-    const { transaction, signers } = await this.makeSendTakeTransaction<
-      Account
-    >(connection, {
-      owner,
-      baseWallet,
-      quoteWallet,
-      side,
-      price,
-      maxBaseSize,
-      maxQuoteSize,
-      minBaseSize,
-      minQuoteSize,
-      limit,
-      programId,
-      feeDiscountPubkey,
-    });
+    const { transaction, signers } =
+      await this.makeSendTakeTransaction<Account>(connection, {
+        owner,
+        baseWallet,
+        quoteWallet,
+        side,
+        price,
+        maxBaseSize,
+        maxQuoteSize,
+        minBaseSize,
+        minQuoteSize,
+        limit,
+        programId,
+        feeDiscountPubkey,
+      });
     return await this._sendTransaction(connection, transaction, [
       owner,
       ...signers,
@@ -709,7 +707,12 @@ export class Market {
       if (openOrdersAccount) {
         account = openOrdersAccount;
       } else {
-        account = new Account();
+        const marketAddress = this.address.toBase58();
+        account = PublicKey.createWithSeed(
+          ownerAddress,
+          marketAddress.slice(0, 32),
+          this.programId,
+        );
       }
       transaction.add(
         await OpenOrders.makeCreateAccountTransaction(
@@ -1826,9 +1829,8 @@ export class Orderbook {
     for (const { key, quantity } of this.slab.items(descending)) {
       const price = getPriceFromKey(key);
       if (levels.length > 0 && levels[levels.length - 1][0].eq(price)) {
-        levels[levels.length - 1][1] = levels[levels.length - 1][1].add(
-          quantity,
-        );
+        levels[levels.length - 1][1] =
+          levels[levels.length - 1][1].add(quantity);
       } else if (levels.length === depth) {
         break;
       } else {


### PR DESCRIPTION
[See line 710 (the rest is just code formatting)]

# Problem
Today, Open Orders Accounts are a major issue for any GUI working with OpenBook and trying to load their users' orders and unsettled balance.

We need to rely on a `getProgramAccount` call to our RPC nodes that needs to process the full OpenBook account to filter out the ones corresponding to the current market and the current user.

# Proposed solution
After chatting with `@tjasd` from Solend, here is how we want to solve it:

https://github.com/openbook-dex/openbook-ts/blob/master/packages/serum/src/market.ts#L712 => change this random Account() creation with a createWithSeed() (https://solana-labs.github.io/solana-web3.js/classes/PublicKey.html#createWithSeed)

This would enable us to use a layout like `{pubKey}+{market address slice}+{programId}` and be able to re-create the address from the frontend without having to ask the blockchain through a massively slow getProgramAccounts

It would not break backward compatibility but could let us transition slowly to fully non getProgramAccount dependant GUI. There will be a need to migrate the old randomly created open order accounts tho if you want to stop using getProgramAccount calls 

# Next step
Battle plan for legacy accounts migration (not necessary to keep all GUIs working but would be awesome to have a migration flow so we can all stop using `gPA`s)
