### PR TITLE
Try loading OpenOrders from their seed based accounts

### DIFF
--- a/packages/serum/src/market.ts
+++ b/packages/serum/src/market.ts
@@ -712,7 +712,7 @@ export class Market {
         account = openOrdersAccount;
       } else {
         const { ooAccountPubkey, ooAccountSeed } =
-          await OpenOrders.getDerivedOOAcountPubkey(
+          await OpenOrders.getDerivedOOAccountPubkey(
             ownerAddress,
             this.address,
             this.programId,
@@ -1692,7 +1692,7 @@ export class OpenOrders {
     return _OPEN_ORDERS_LAYOUT_V2;
   }
 
-  static async getDerivedOOAcountPubkey(
+  static async getDerivedOOAccountPubkey(
     ownerAddress: PublicKey,
     marketAddress: PublicKey,
     programId: PublicKey,
@@ -1739,7 +1739,7 @@ export class OpenOrders {
     programId: PublicKey,
   ): Promise<OpenOrders[]> {
     // Try loading seed based accounts
-    const { ooAccountPubkey } = await this.getDerivedOOAcountPubkey(
+    const { ooAccountPubkey } = await this.getDerivedOOAccountPubkey(
       ownerAddress,
       marketAddress,
       programId,

--- a/packages/serum/src/market.ts
+++ b/packages/serum/src/market.ts
@@ -1720,7 +1720,22 @@ export class OpenOrders {
     marketAddress: PublicKey,
     ownerAddress: PublicKey,
     programId: PublicKey,
-  ) {
+  ): Promise<OpenOrders[]> {
+    // Try loading seed based accounts
+    const seed = marketAddress.toBase58().slice(0, 32);
+    const ooAccountPubkey = await PublicKey.createWithSeed(
+      ownerAddress,
+      seed,
+      programId,
+    );
+    const ooAccountInfo = await connection.getAccountInfo(ooAccountPubkey);
+    if (ooAccountInfo) {
+      return [
+        OpenOrders.fromAccountInfo(ownerAddress, ooAccountInfo, programId),
+      ];
+    }
+
+    // Fallback to legacy gPA loading
     const filters = [
       {
         memcmp: {

--- a/packages/serum/src/market.ts
+++ b/packages/serum/src/market.ts
@@ -396,6 +396,7 @@ export class Market {
     connection: Connection,
     ownerAddress: PublicKey,
     cacheDurationMs = 0,
+    forceSeedAccount: boolean = false,
   ): Promise<OpenOrders[]> {
     const strOwner = ownerAddress.toBase58();
     const now = new Date().getTime();
@@ -410,6 +411,7 @@ export class Market {
       this.address,
       ownerAddress,
       this._programId,
+      forceSeedAccount,
     );
     this._openOrdersAccountsCache[strOwner] = {
       accounts: openOrdersAccountsForOwner,
@@ -703,9 +705,6 @@ export class Market {
 
     let openOrdersAddress: PublicKey;
     if (openOrdersAccounts.length === 0) {
-      // const marketAddress = this.address.toBase58();
-      // const seed = marketAddress.slice(0, 32);
-
       let account;
 
       if (openOrdersAccount) {
@@ -1737,6 +1736,7 @@ export class OpenOrders {
     marketAddress: PublicKey,
     ownerAddress: PublicKey,
     programId: PublicKey,
+    forceSeedAccount: boolean = false,
   ): Promise<OpenOrders[]> {
     // Try loading seed based accounts
     const { ooAccountPubkey } = await this.getDerivedOOAccountPubkey(
@@ -1747,8 +1747,12 @@ export class OpenOrders {
     const ooAccountInfo = await connection.getAccountInfo(ooAccountPubkey);
     if (ooAccountInfo) {
       return [
-        OpenOrders.fromAccountInfo(ownerAddress, ooAccountInfo, programId),
+        OpenOrders.fromAccountInfo(ooAccountPubkey, ooAccountInfo, programId),
       ];
+    }
+
+    if (forceSeedAccount) {
+      return [];
     }
 
     // Fallback to legacy gPA loading

--- a/packages/serum/src/market.ts
+++ b/packages/serum/src/market.ts
@@ -710,16 +710,11 @@ export class Market {
       if (openOrdersAccount) {
         account = openOrdersAccount;
       } else {
-        const { ooAccountPubkey, ooAccountSeed } =
-          await OpenOrders.getDerivedOOAccountPubkey(
-            ownerAddress,
-            this.address,
-            this.programId,
-          );
-        account = {
-          publicKey: ooAccountPubkey,
-          seed: ooAccountSeed,
-        };
+        account = await OpenOrders.getDerivedOOAccountPubkey(
+          ownerAddress,
+          this.address,
+          this.programId,
+        );
       }
       transaction.add(
         await OpenOrders.makeCreateAccountTransaction(
@@ -732,7 +727,6 @@ export class Market {
         ),
       );
       openOrdersAddress = account.publicKey;
-      // signers.push(ownerAddress);
       // refresh the cache of open order accounts on next fetch
       this._openOrdersAccountsCache[ownerAddress.toBase58()].ts = 0;
     } else if (openOrdersAccount) {
@@ -1702,7 +1696,7 @@ export class OpenOrders {
       seed,
       programId,
     );
-    return { ooAccountPubkey: publicKey, ooAccountSeed: seed };
+    return { publicKey, seed };
   }
 
   static async findForOwner(
@@ -1739,15 +1733,15 @@ export class OpenOrders {
     forceSeedAccount: boolean = false,
   ): Promise<OpenOrders[]> {
     // Try loading seed based accounts
-    const { ooAccountPubkey } = await this.getDerivedOOAccountPubkey(
+    const account = await this.getDerivedOOAccountPubkey(
       ownerAddress,
       marketAddress,
       programId,
     );
-    const ooAccountInfo = await connection.getAccountInfo(ooAccountPubkey);
+    const ooAccountInfo = await connection.getAccountInfo(account.publicKey);
     if (ooAccountInfo) {
       return [
-        OpenOrders.fromAccountInfo(ooAccountPubkey, ooAccountInfo, programId),
+        OpenOrders.fromAccountInfo(account.publicKey, ooAccountInfo, programId),
       ];
     }
 

--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -192,7 +192,7 @@ export class Swap {
         toMint,
       );
       const { ooAccountPubkey, ooAccountSeed } =
-        await OpenOrders.getDerivedOOAcountPubkey(
+        await OpenOrders.getDerivedOOAccountPubkey(
           this.program.provider.wallet.publicKey,
           marketAddress,
           DEX_PID,
@@ -228,7 +228,7 @@ export class Swap {
         fromMint,
       );
       const { ooAccountPubkey, ooAccountSeed } =
-        await OpenOrders.getDerivedOOAcountPubkey(
+        await OpenOrders.getDerivedOOAccountPubkey(
           this.program.provider.wallet.publicKey,
           marketAddress,
           DEX_PID,
@@ -296,7 +296,7 @@ export class Swap {
         if (!ooAccsFrom[0]) {
           // const ooFrom = new Account();
           const { ooAccountPubkey, ooAccountSeed } =
-            await OpenOrders.getDerivedOOAcountPubkey(
+            await OpenOrders.getDerivedOOAccountPubkey(
               this.program.provider.wallet.publicKey,
               marketTo,
               DEX_PID,
@@ -329,7 +329,7 @@ export class Swap {
         if (!ooAccsTo[0]) {
           // const ooTo = new Account();
           const { ooAccountPubkey, ooAccountSeed } =
-            await OpenOrders.getDerivedOOAcountPubkey(
+            await OpenOrders.getDerivedOOAccountPubkey(
               this.program.provider.wallet.publicKey,
               marketTo,
               DEX_PID,
@@ -711,7 +711,7 @@ export class Swap {
       // signers.push(oo);
       // openOrders = oo.publicKey;
       const { ooAccountPubkey, ooAccountSeed } =
-        await OpenOrders.getDerivedOOAcountPubkey(
+        await OpenOrders.getDerivedOOAccountPubkey(
           this.program.provider.wallet.publicKey,
           marketClient.address,
           DEX_PID,

--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -190,7 +190,7 @@ export class Swap {
         fromMint,
         toMint,
       );
-      const account = await OpenOrders.getDerivedOOAccountPubkey(
+      const openOrders = await OpenOrders.getDerivedOOAccountPubkey(
         this.program.provider.wallet.publicKey,
         marketAddress,
         DEX_PID,
@@ -200,15 +200,15 @@ export class Swap {
           this.program.provider.connection,
           marketAddress,
           this.program.provider.wallet.publicKey,
-          account.publicKey,
+          openOrders.publicKey,
           DEX_PID,
-          account.seed,
+          openOrders.seed,
         ),
       );
       tx.add(
         this.program.instruction.initAccount({
           accounts: {
-            openOrders: account.publicKey,
+            openOrders: openOrders.publicKey,
             authority: this.program.provider.wallet.publicKey,
             market: marketAddress,
             dexProgram: DEX_PID,
@@ -223,7 +223,7 @@ export class Swap {
         toMint,
         fromMint,
       );
-      const account = await OpenOrders.getDerivedOOAccountPubkey(
+      const openOrders = await OpenOrders.getDerivedOOAccountPubkey(
         this.program.provider.wallet.publicKey,
         marketAddress,
         DEX_PID,
@@ -233,15 +233,15 @@ export class Swap {
           this.program.provider.connection,
           marketAddress,
           this.program.provider.wallet.publicKey,
-          account.publicKey,
+          openOrders.publicKey,
           DEX_PID,
-          account.seed,
+          openOrders.seed,
         ),
       );
       tx.add(
         this.program.instruction.initAccount({
           accounts: {
-            openOrders: account.publicKey,
+            openOrders: openOrders.publicKey,
             authority: this.program.provider.wallet.publicKey,
             market: marketAddress,
             dexProgram: DEX_PID,
@@ -288,7 +288,7 @@ export class Swap {
 
         // No open orders account for the from market, so make it.
         if (!ooAccsFrom[0]) {
-          const account = await OpenOrders.getDerivedOOAccountPubkey(
+          const ooFrom = await OpenOrders.getDerivedOOAccountPubkey(
             this.program.provider.wallet.publicKey,
             marketTo,
             DEX_PID,
@@ -298,15 +298,15 @@ export class Swap {
               this.program.provider.connection,
               marketFrom,
               this.program.provider.wallet.publicKey,
-              account.publicKey,
+              ooFrom.publicKey,
               DEX_PID,
-              account.seed,
+              ooFrom.seed,
             ),
           );
           ixs.push(
             this.program.instruction.initAccount({
               accounts: {
-                openOrders: account.publicKey,
+                openOrders: ooFrom.publicKey,
                 authority: this.program.provider.wallet.publicKey,
                 market: marketFrom,
                 dexProgram: DEX_PID,

--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -186,32 +186,29 @@ export class Swap {
 
     // Direct swap on USD(x).
     if (fromMint.equals(USDC_PUBKEY) || fromMint.equals(USDT_PUBKEY)) {
-      // const openOrders = new Account();
       const marketAddress = await this.swapMarkets.getMarketAddressIfNeeded(
         fromMint,
         toMint,
       );
-      const { ooAccountPubkey, ooAccountSeed } =
-        await OpenOrders.getDerivedOOAccountPubkey(
-          this.program.provider.wallet.publicKey,
-          marketAddress,
-          DEX_PID,
-        );
+      const account = await OpenOrders.getDerivedOOAccountPubkey(
+        this.program.provider.wallet.publicKey,
+        marketAddress,
+        DEX_PID,
+      );
       tx.add(
         await OpenOrders.makeCreateAccountTransaction(
           this.program.provider.connection,
           marketAddress,
           this.program.provider.wallet.publicKey,
-          ooAccountPubkey,
+          account.publicKey,
           DEX_PID,
-          ooAccountSeed,
+          account.seed,
         ),
       );
-      // signers.push(openOrders);
       tx.add(
         this.program.instruction.initAccount({
           accounts: {
-            openOrders: ooAccountPubkey,
+            openOrders: account.publicKey,
             authority: this.program.provider.wallet.publicKey,
             market: marketAddress,
             dexProgram: DEX_PID,
@@ -226,26 +223,25 @@ export class Swap {
         toMint,
         fromMint,
       );
-      const { ooAccountPubkey, ooAccountSeed } =
-        await OpenOrders.getDerivedOOAccountPubkey(
-          this.program.provider.wallet.publicKey,
-          marketAddress,
-          DEX_PID,
-        );
+      const account = await OpenOrders.getDerivedOOAccountPubkey(
+        this.program.provider.wallet.publicKey,
+        marketAddress,
+        DEX_PID,
+      );
       tx.add(
         await OpenOrders.makeCreateAccountTransaction(
           this.program.provider.connection,
           marketAddress,
           this.program.provider.wallet.publicKey,
-          ooAccountPubkey,
+          account.publicKey,
           DEX_PID,
-          ooAccountSeed,
+          account.seed,
         ),
       );
       tx.add(
         this.program.instruction.initAccount({
           accounts: {
-            openOrders: ooAccountPubkey,
+            openOrders: account.publicKey,
             authority: this.program.provider.wallet.publicKey,
             market: marketAddress,
             dexProgram: DEX_PID,
@@ -253,7 +249,6 @@ export class Swap {
           },
         }),
       );
-      // signers.push(openOrders);
     }
     // Transitive swap across USD(x).
     else {
@@ -293,27 +288,25 @@ export class Swap {
 
         // No open orders account for the from market, so make it.
         if (!ooAccsFrom[0]) {
-          // const ooFrom = new Account();
-          const { ooAccountPubkey, ooAccountSeed } =
-            await OpenOrders.getDerivedOOAccountPubkey(
-              this.program.provider.wallet.publicKey,
-              marketTo,
-              DEX_PID,
-            );
+          const account = await OpenOrders.getDerivedOOAccountPubkey(
+            this.program.provider.wallet.publicKey,
+            marketTo,
+            DEX_PID,
+          );
           ixs.push(
             await OpenOrders.makeCreateAccountTransaction(
               this.program.provider.connection,
               marketFrom,
               this.program.provider.wallet.publicKey,
-              ooAccountPubkey,
+              account.publicKey,
               DEX_PID,
-              ooAccountSeed,
+              account.seed,
             ),
           );
           ixs.push(
             this.program.instruction.initAccount({
               accounts: {
-                openOrders: ooAccountPubkey,
+                openOrders: account.publicKey,
                 authority: this.program.provider.wallet.publicKey,
                 market: marketFrom,
                 dexProgram: DEX_PID,
@@ -321,32 +314,30 @@ export class Swap {
               },
             }),
           );
-          // sigs.push(ooFrom);
         }
 
         // No open orders account for the to market, so make it.
         if (!ooAccsTo[0]) {
           // const ooTo = new Account();
-          const { ooAccountPubkey, ooAccountSeed } =
-            await OpenOrders.getDerivedOOAccountPubkey(
-              this.program.provider.wallet.publicKey,
-              marketTo,
-              DEX_PID,
-            );
+          const account = await OpenOrders.getDerivedOOAccountPubkey(
+            this.program.provider.wallet.publicKey,
+            marketTo,
+            DEX_PID,
+          );
           ixs.push(
             await OpenOrders.makeCreateAccountTransaction(
               this.program.provider.connection,
               marketTo,
               this.program.provider.wallet.publicKey,
-              ooAccountPubkey,
+              account.publicKey,
               DEX_PID,
-              ooAccountSeed,
+              account.seed,
             ),
           );
           ixs.push(
             this.program.instruction.initAccount({
               accounts: {
-                openOrders: ooAccountPubkey,
+                openOrders: account.publicKey,
                 authority: this.program.provider.wallet.publicKey,
                 market: marketTo,
                 dexProgram: DEX_PID,
@@ -354,7 +345,6 @@ export class Swap {
               },
             }),
           );
-          // sigs.push(ooAccountPubkey);
         }
 
         // Done.
@@ -709,20 +699,19 @@ export class Swap {
       // const oo = new Account();
       // signers.push(oo);
       // openOrders = oo.publicKey;
-      const { ooAccountPubkey, ooAccountSeed } =
-        await OpenOrders.getDerivedOOAccountPubkey(
-          this.program.provider.wallet.publicKey,
-          marketClient.address,
-          DEX_PID,
-        );
+      const account = await OpenOrders.getDerivedOOAccountPubkey(
+        this.program.provider.wallet.publicKey,
+        marketClient.address,
+        DEX_PID,
+      );
       ixs.push(
         await OpenOrders.makeCreateAccountTransaction(
           this.program.provider.connection,
           marketClient.address,
           this.program.provider.wallet.publicKey,
-          ooAccountPubkey,
+          account.publicKey,
           DEX_PID,
-          ooAccountSeed,
+          account.seed,
         ),
       );
     }

--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -318,8 +318,7 @@ export class Swap {
 
         // No open orders account for the to market, so make it.
         if (!ooAccsTo[0]) {
-          // const ooTo = new Account();
-          const account = await OpenOrders.getDerivedOOAccountPubkey(
+          const ooTo = await OpenOrders.getDerivedOOAccountPubkey(
             this.program.provider.wallet.publicKey,
             marketTo,
             DEX_PID,
@@ -329,15 +328,15 @@ export class Swap {
               this.program.provider.connection,
               marketTo,
               this.program.provider.wallet.publicKey,
-              account.publicKey,
+              ooTo.publicKey,
               DEX_PID,
-              account.seed,
+              ooTo.seed,
             ),
           );
           ixs.push(
             this.program.instruction.initAccount({
               accounts: {
-                openOrders: account.publicKey,
+                openOrders: ooTo.publicKey,
                 authority: this.program.provider.wallet.publicKey,
                 market: marketTo,
                 dexProgram: DEX_PID,
@@ -696,10 +695,7 @@ export class Swap {
 
     // Create the open orders account, if needed.
     if (needsOpenOrders) {
-      // const oo = new Account();
-      // signers.push(oo);
-      // openOrders = oo.publicKey;
-      const account = await OpenOrders.getDerivedOOAccountPubkey(
+      const ooAccount = await OpenOrders.getDerivedOOAccountPubkey(
         this.program.provider.wallet.publicKey,
         marketClient.address,
         DEX_PID,
@@ -709,9 +705,9 @@ export class Swap {
           this.program.provider.connection,
           marketClient.address,
           this.program.provider.wallet.publicKey,
-          account.publicKey,
+          ooAccount.publicKey,
           DEX_PID,
-          account.seed,
+          ooAccount.seed,
         ),
       );
     }

--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -222,7 +222,6 @@ export class Swap {
     }
     // Direct swap on USD(x).
     else if (toMint.equals(USDC_PUBKEY) || toMint.equals(USDT_PUBKEY)) {
-      // const openOrders = new Account();
       const marketAddress = await this.swapMarkets.getMarketAddressIfNeeded(
         toMint,
         fromMint,

--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -186,25 +186,32 @@ export class Swap {
 
     // Direct swap on USD(x).
     if (fromMint.equals(USDC_PUBKEY) || fromMint.equals(USDT_PUBKEY)) {
-      const openOrders = new Account();
+      // const openOrders = new Account();
       const marketAddress = await this.swapMarkets.getMarketAddressIfNeeded(
         fromMint,
         toMint,
       );
+      const { ooAccountPubkey, ooAccountSeed } =
+        await OpenOrders.getDerivedOOAcountPubkey(
+          this.program.provider.wallet.publicKey,
+          marketAddress,
+          DEX_PID,
+        );
       tx.add(
         await OpenOrders.makeCreateAccountTransaction(
           this.program.provider.connection,
           marketAddress,
           this.program.provider.wallet.publicKey,
-          openOrders.publicKey,
+          ooAccountPubkey,
           DEX_PID,
+          ooAccountSeed,
         ),
       );
-      signers.push(openOrders);
+      // signers.push(openOrders);
       tx.add(
         this.program.instruction.initAccount({
           accounts: {
-            openOrders: openOrders.publicKey,
+            openOrders: ooAccountPubkey,
             authority: this.program.provider.wallet.publicKey,
             market: marketAddress,
             dexProgram: DEX_PID,
@@ -215,24 +222,31 @@ export class Swap {
     }
     // Direct swap on USD(x).
     else if (toMint.equals(USDC_PUBKEY) || toMint.equals(USDT_PUBKEY)) {
-      const openOrders = new Account();
+      // const openOrders = new Account();
       const marketAddress = await this.swapMarkets.getMarketAddressIfNeeded(
         toMint,
         fromMint,
       );
+      const { ooAccountPubkey, ooAccountSeed } =
+        await OpenOrders.getDerivedOOAcountPubkey(
+          this.program.provider.wallet.publicKey,
+          marketAddress,
+          DEX_PID,
+        );
       tx.add(
         await OpenOrders.makeCreateAccountTransaction(
           this.program.provider.connection,
           marketAddress,
           this.program.provider.wallet.publicKey,
-          openOrders.publicKey,
+          ooAccountPubkey,
           DEX_PID,
+          ooAccountSeed,
         ),
       );
       tx.add(
         this.program.instruction.initAccount({
           accounts: {
-            openOrders: openOrders.publicKey,
+            openOrders: ooAccountPubkey,
             authority: this.program.provider.wallet.publicKey,
             market: marketAddress,
             dexProgram: DEX_PID,
@@ -240,7 +254,7 @@ export class Swap {
           },
         }),
       );
-      signers.push(openOrders);
+      // signers.push(openOrders);
     }
     // Transitive swap across USD(x).
     else {
@@ -280,20 +294,27 @@ export class Swap {
 
         // No open orders account for the from market, so make it.
         if (!ooAccsFrom[0]) {
-          const ooFrom = new Account();
+          // const ooFrom = new Account();
+          const { ooAccountPubkey, ooAccountSeed } =
+            await OpenOrders.getDerivedOOAcountPubkey(
+              this.program.provider.wallet.publicKey,
+              marketTo,
+              DEX_PID,
+            );
           ixs.push(
             await OpenOrders.makeCreateAccountTransaction(
               this.program.provider.connection,
               marketFrom,
               this.program.provider.wallet.publicKey,
-              ooFrom.publicKey,
+              ooAccountPubkey,
               DEX_PID,
+              ooAccountSeed,
             ),
           );
           ixs.push(
             this.program.instruction.initAccount({
               accounts: {
-                openOrders: ooFrom.publicKey,
+                openOrders: ooAccountPubkey,
                 authority: this.program.provider.wallet.publicKey,
                 market: marketFrom,
                 dexProgram: DEX_PID,
@@ -301,25 +322,32 @@ export class Swap {
               },
             }),
           );
-          sigs.push(ooFrom);
+          // sigs.push(ooFrom);
         }
 
         // No open orders account for the to market, so make it.
         if (!ooAccsTo[0]) {
-          const ooTo = new Account();
+          // const ooTo = new Account();
+          const { ooAccountPubkey, ooAccountSeed } =
+            await OpenOrders.getDerivedOOAcountPubkey(
+              this.program.provider.wallet.publicKey,
+              marketTo,
+              DEX_PID,
+            );
           ixs.push(
             await OpenOrders.makeCreateAccountTransaction(
               this.program.provider.connection,
               marketTo,
               this.program.provider.wallet.publicKey,
-              ooTo.publicKey,
+              ooAccountPubkey,
               DEX_PID,
+              ooAccountSeed,
             ),
           );
           ixs.push(
             this.program.instruction.initAccount({
               accounts: {
-                openOrders: ooTo.publicKey,
+                openOrders: ooAccountPubkey,
                 authority: this.program.provider.wallet.publicKey,
                 market: marketTo,
                 dexProgram: DEX_PID,
@@ -327,7 +355,7 @@ export class Swap {
               },
             }),
           );
-          sigs.push(ooTo);
+          // sigs.push(ooAccountPubkey);
         }
 
         // Done.
@@ -679,16 +707,23 @@ export class Swap {
 
     // Create the open orders account, if needed.
     if (needsOpenOrders) {
-      const oo = new Account();
-      signers.push(oo);
-      openOrders = oo.publicKey;
+      // const oo = new Account();
+      // signers.push(oo);
+      // openOrders = oo.publicKey;
+      const { ooAccountPubkey, ooAccountSeed } =
+        await OpenOrders.getDerivedOOAcountPubkey(
+          this.program.provider.wallet.publicKey,
+          marketClient.address,
+          DEX_PID,
+        );
       ixs.push(
         await OpenOrders.makeCreateAccountTransaction(
           this.program.provider.connection,
           marketClient.address,
           this.program.provider.wallet.publicKey,
-          oo.publicKey,
+          ooAccountPubkey,
           DEX_PID,
+          ooAccountSeed,
         ),
       );
     }


### PR DESCRIPTION
Follow up of https://github.com/openbook-dex/openbook-ts/pull/15

## Adding a way to load open order accounts created from a seed

The `OpenOrders` class's method `findForMarketAndOwner` loads the open order for a specific market and a specific user. This is the best way to load the open order that are used on the trading page.

Since those are now created with a seed, we do not have to rely on `getProgramAccounts` to load them.

This is a first draft that does not include updating old open orders accounts to new seed based ones.

## Force seed account
The default behavior is as follows:
1. Try to load the `derivedOOAccount`
2. If this account is empty try to load all `OOAccounts` attached to this wallet + market through a gPA 

The issue is that if you want to stop using gPA 100% this will still call a gPA to try and load accounts.

I added a `forceSeedAccount` in the `findOpenOrdersAccountsForOwner` method so that a DEX can fully switch to stop using gPA (this is something that I want for Solape specifically but I imagine many DEXs will follow)
 
What are the opinions on this?