### PR TITLE
fix: invalid payer account error handling is at the wrong depth

### DIFF
--- a/packages/openbook/src/market.ts
+++ b/packages/openbook/src/market.ts
@@ -774,9 +774,9 @@ export class Market {
           }),
         );
         signers.push(wrappedSolAccount);
-      } else {
-        throw new Error('Invalid payer account');
       }
+    } else {
+      throw new Error('Invalid payer account');
     }
 
     const placeOrderInstruction = this.makePlaceOrderInstruction(connection, {


### PR DESCRIPTION
I noticed the error was being thrown for non SOL markets, because of a false value in this statement;

```
if (
        (side === 'buy' && this.quoteMintAddress.equals(WRAPPED_SOL_MINT)) ||
        (side === 'sell' && this.baseMintAddress.equals(WRAPPED_SOL_MINT))
      ) {
```

That statement only checks for a wrapping requirement and doesn't do the wrapping for non-SOL markets. The error message is related to the payer account, which doesn't make sense.

I believe that else statement was intended for failing the outer check for ```payer.equals(owner)```

Alternatively, removing the payer.equals(owner) check entirely, could handle more cases, but I'm not sure of the side effects.